### PR TITLE
Empty Subtitle Fix

### DIFF
--- a/template_helpers.js
+++ b/template_helpers.js
@@ -290,7 +290,7 @@
      */
     Handlebars.registerHelper("formatSubtitle", function(components) {
         // don't leave a blank spot in the template
-        if (!components) { return '&nbsp;' }
+        if (!components) { return '&nbsp;'; }
 
         components = $.isArray(components) ? components: [components];
 

--- a/template_helpers.js
+++ b/template_helpers.js
@@ -289,6 +289,9 @@
      * @return {string}
      */
     Handlebars.registerHelper("formatSubtitle", function(components) {
+        // don't leave a blank spot in the template
+        if (!components) { return '&nbsp;' }
+
         components = $.isArray(components) ? components: [components];
 
         return DDG.exec_template('subtitle', {


### PR DESCRIPTION
Occasionally the data for the `subtitle` field comes up blank, and that can cause a problem in dynamically-sized tiles.  The entire subtitle element collapses!  This returns an empty character, which saves everyone a bit of a headache. :smile: 

to @andrey-p 
cc @bsstoner @jagtalon 
