### PR TITLE
fix ellipsis limit and test

### DIFF
--- a/template_helpers.js
+++ b/template_helpers.js
@@ -202,7 +202,7 @@
      * 
      */
     Handlebars.registerHelper("ellipsis", function(text, limit, options) {
-        if (!text) { return; }
+        if (!text) { return ""; }
 
         // If we get a number, convert it to a string.
         // We convert things to a string because [object Number] doesn't have the `split` method.

--- a/template_helpers.js
+++ b/template_helpers.js
@@ -224,8 +224,8 @@
             words = text.split(" ");
 
         for(var i = 0; i < words.length; i++) {
-            count += words[i].length + 1;
-            if(count < limit) {
+            count += words[i].length + (i < words.length-1 ? 1 : 0);
+            if(count <= limit) {
                 result.push(words[i]);
             }
         }

--- a/test/ellipsis.js
+++ b/test/ellipsis.js
@@ -1,7 +1,10 @@
 describe('Handlebars.helpers.ellipsis', function() {
 
     var tests = [
-        { text: 'The quick brown fox', len: 12, expected: 'The quick...' }
+        { text: '', len: 1, expected: undefined },
+        { text: 'The quick brown fox', len: 12, expected: 'The quick...' },
+        { text: 'This is shorter than the limit', len: 42, expected: 'This is shorter than the limit' },
+        { text: 'This is as long as the limit', len: 28, expected: 'This is as long as the limit' },
     ];
 
     it('should truncate words correctly', function() {

--- a/test/ellipsis.js
+++ b/test/ellipsis.js
@@ -1,7 +1,7 @@
 describe('Handlebars.helpers.ellipsis', function() {
 
     var tests = [
-        { text: '', len: 1, expected: undefined },
+        { text: '', len: 1, expected: '' },
         { text: 'The quick brown fox', len: 12, expected: 'The quick...' },
         { text: 'This is shorter than the limit', len: 42, expected: 'This is shorter than the limit' },
         { text: 'This is as long as the limit', len: 28, expected: 'This is as long as the limit' },


### PR DESCRIPTION
The `ellipsis` helper seem to be off regarding its limit.

In the docs it says: `Shortens a string by removing words until string length is <= 'limit'...`, but then the code was using `<` instead. Besides that, it was taking the space after the last word into account, when it shouldn't (as it's the last word, there shouldn't be a ws after it)

:dancer: my first PR in this repo!!!
