### PR TITLE
Remove "Block Helper" comment from Condense

### DIFF
--- a/template_helpers.js
+++ b/template_helpers.js
@@ -93,8 +93,6 @@
 
     /**
      * @function condense
-     *
-     * **Block Helper**
      * 
      * Shortens a string
      * 


### PR DESCRIPTION
The `condense` helper isn't a block helper, so I've removed that from the comments.
