### PR TITLE
Use full titles in formatTitle helper unless explicitly overridden

### DIFF
--- a/template_helpers.js
+++ b/template_helpers.js
@@ -324,7 +324,12 @@
             obj = DDG.parse_link(obj,"text");
         }
 
-        var tile = DDG.parseAbstract(obj);
+        var tile = DDG.parseAbstract(obj),
+            title = tile.main;
+
+        if (ops.ellipsis) {
+            title = Handlebars.helpers.ellipsis(tile.main, ops.ellipsis);
+        }
 
         return DDG.exec_template('title', {
             tagName: ops.el || 'span',
@@ -332,7 +337,7 @@
             classNameSec: ops.classNameSec,
             subTitle: !ops.noSub && tile.subTitle,
             optSub: ops.optSub,
-            title: Handlebars.helpers.ellipsis(tile.main, ops.ellipsis),
+            title: title,
             href: (ops.href && this[ops.href]) || ops.href,
             hrefTitle: tile.main && !tile.main.match(/<b>/) ? tile.main : null
         });


### PR DESCRIPTION
All instances of formatTitle in templates:
![screen shot 2016-09-12 at 7 53 33 am](https://cloud.githubusercontent.com/assets/126358/18434961/58fef156-78be-11e6-8596-eecf5ee887e4.png)

I added `ellipsis=100` (the current default) to all those templates that didn't already have a value set, with the exception of `nlp_detail`:
https://github.com/duckduckgo/duckduckgo-answerbar-templates/pull/38

So the net change should be no ellipsis on `nlp_detail` titles anymore:
![screen shot 2016-09-12 at 8 01 07 am](https://cloud.githubusercontent.com/assets/126358/18435072/164c2d46-78bf-11e6-94d8-cd5562170b07.png)

@bbraithwaite 
cc @zachthompson @b2ddg @andrey-p 
