### PR TITLE
Add helpers

### DIFF
--- a/template_helpers.js
+++ b/template_helpers.js
@@ -981,7 +981,7 @@
         }
         
         // Inverse of equals
-        return Handlebars.helpers['ifEquals'].call(this, a, b, {
+        return Handlebars.helpers.ifEquals.call(this, a, b, {
             fn: options.inverse,
             inverse: options.fn,
             hash: options.hash

--- a/template_helpers.js
+++ b/template_helpers.js
@@ -940,4 +940,25 @@
         return '<div class="loader" style="background-image:url(\'' + src + '\');"></div>';
     });
 
+    /**
+     * For adding equality check 
+     *
+     */
+    Handlebars.registerHelper("ifEq", function(a, b, options) {
+        if(a === b) {
+            return options.fn(this);
+        } 
+        return options.inverse(this);
+    });
+
+    /**
+     * For adding inequality check 
+     *
+     */
+    Handlebars.registerHelper("ifNeq", function(a, b, options) {
+        if(a !== b) {
+            return options.fn(this);
+        } 
+        return options.inverse(this);
+    });
 })(this);

--- a/template_helpers.js
+++ b/template_helpers.js
@@ -941,24 +941,55 @@
     });
 
     /**
-     * For adding equality check 
+     *  @function ifEquals
+     * 
+     * For adding equality check for an object key
+     * 
+     * @return {string}
      *
+     * Example: {{#ifEquals color "red"}}
+     *          {{/ifEquals}}
+     *          
+     *          {{#ifEquals color "green"}}
+     *          {{/ifEquals}}
      */
-    Handlebars.registerHelper("ifEq", function(a, b, options) {
-        if(a === b) {
+    Handlebars.registerHelper("ifEquals", function(a, b, options) {
+        if (arguments.length !== 3) {
+            throw new Exception('#ifEquals requires exactly 2 arguments');
+        }
+
+        if (a === b) {
             return options.fn(this);
-        } 
+        }
+         
         return options.inverse(this);
     });
 
     /**
-     * For adding inequality check 
+     *  @function ifNotEquals
+     * 
+     * For adding equality check for an object key
+     * 
+     * @return {string}
      *
+     * Example: {{#ifNotEquals color "red"}}
+     *          {{/ifNotEquals}}
      */
-    Handlebars.registerHelper("ifNeq", function(a, b, options) {
-        if(a !== b) {
-            return options.fn(this);
-        } 
-        return options.inverse(this);
+    Handlebars.registerHelper("ifNotEquals", function(a, b, options) {
+        if (arguments.length !== 3) {
+            throw new Exception('#ifNotEquals requires exactly 2 arguments');
+        }
+
+        // if (a !== b) {
+        //     return options.fn(this);
+        // } 
+
+        // return options.inverse(this);
+
+        return Handlebars.helpers['ifEquals'].call(this, a, b, {
+            fn: options.inverse,
+            inverse: options.fn,
+            hash: options.hash
+        })
     });
 })(this);

--- a/template_helpers.js
+++ b/template_helpers.js
@@ -979,11 +979,12 @@
         if (arguments.length !== 3) {
             throw new Error('#ifNotEquals requires exactly 2 arguments');
         }
-
+        
+        // Inverse of equals
         return Handlebars.helpers['ifEquals'].call(this, a, b, {
             fn: options.inverse,
             inverse: options.fn,
             hash: options.hash
-        })
+        });
     });
 })(this);

--- a/template_helpers.js
+++ b/template_helpers.js
@@ -943,7 +943,7 @@
     /**
      *  @function ifEquals
      * 
-     * For adding equality check for an object key
+     * Equality check for an object key
      * 
      * @return {string}
      *
@@ -955,7 +955,7 @@
      */
     Handlebars.registerHelper("ifEquals", function(a, b, options) {
         if (arguments.length !== 3) {
-            throw new Exception('#ifEquals requires exactly 2 arguments');
+            throw new Error('#ifEquals requires exactly 2 arguments');
         }
 
         if (a === b) {
@@ -968,7 +968,7 @@
     /**
      *  @function ifNotEquals
      * 
-     * For adding equality check for an object key
+     * Inequality check for an object key
      * 
      * @return {string}
      *
@@ -977,14 +977,8 @@
      */
     Handlebars.registerHelper("ifNotEquals", function(a, b, options) {
         if (arguments.length !== 3) {
-            throw new Exception('#ifNotEquals requires exactly 2 arguments');
+            throw new Error('#ifNotEquals requires exactly 2 arguments');
         }
-
-        // if (a !== b) {
-        //     return options.fn(this);
-        // } 
-
-        // return options.inverse(this);
 
         return Handlebars.helpers['ifEquals'].call(this, a, b, {
             fn: options.inverse,


### PR DESCRIPTION
Add equals and not equals checks to template helpers. 

This is more expressive in cases where there's a key with multiple different states and explicit mutual exclusivity is important. So instead of having to do this:
```
// Passed into template:
{
  green: false, 
  blue: false,
  red: true
}

// In template
{{#if green}}
    //do something green
{{/if}}
{{#if blue}}
    //do something blue
{{/if}}
{{#if red}}
    //do something red
{{/if}}
```

We can do:
```
// Passed into template:
{
  color: 'green' | 'blue' | 'red', 
}

// In template 
{{#ifEq color "green"}}
    //do something green
{{/ifEq}}
{{#ifEq color "blue"}}
    //do something blue
{{/ifEq}}
{{#ifEq color "red"}}
    //do something red
{{/ifEq}}
```